### PR TITLE
add public function zmq_new_router_socket() to allow passing a "remot…

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -478,6 +478,9 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_PROTOCOL_ERROR_WS_UNSPECIFIED 0x30000000
 
 ZMQ_EXPORT void *zmq_socket (void *, int type_);
+typedef void(zmq_router_skt_peer_connect_notification_fn) (const unsigned char* rmtID_, size_t rmtIDLen_, int connectingElseDisconnecting_, void *hint_);
+ZMQ_EXPORT void *zmq_new_router_socket (void * context_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
+
 ZMQ_EXPORT int zmq_close (void *s_);
 ZMQ_EXPORT int
 zmq_setsockopt (void *s_, int option_, const void *optval_, size_t optvallen_);

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -30,6 +30,7 @@
 #ifndef __ZMQ_CTX_HPP_INCLUDED__
 #define __ZMQ_CTX_HPP_INCLUDED__
 
+#include <functional>
 #include <map>
 #include <vector>
 #include <string>
@@ -120,7 +121,9 @@ class ctx_t ZMQ_FINAL : public thread_ctx_t
     int get (int option_);
 
     //  Create and destroy a socket.
-    zmq::socket_base_t *create_socket (int type_);
+    // if sktAllocFn is empty then it will allocate it using socket_base_t::create(...)
+    zmq::socket_base_t *create_socket (int type_, std::function<zmq::socket_base_t*(int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_)> sktAllocFn = {});
+    zmq::socket_base_t *create_router_socket (zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     void destroy_socket (zmq::socket_base_t *socket_);
 
     //  Send command to the destination thread.

--- a/src/rep.cpp
+++ b/src/rep.cpp
@@ -32,8 +32,8 @@
 #include "err.hpp"
 #include "msg.hpp"
 
-zmq::rep_t::rep_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    router_t (parent_, tid_, sid_),
+zmq::rep_t::rep_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    router_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _sending_reply (false),
     _request_begins (true)
 {

--- a/src/rep.hpp
+++ b/src/rep.hpp
@@ -42,7 +42,7 @@ class socket_base_t;
 class rep_t ZMQ_FINAL : public router_t
 {
   public:
-    rep_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    rep_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~rep_t ();
 
     //  Overrides of functions from socket_base_t.

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -36,8 +36,8 @@
 #include "likely.hpp"
 #include "err.hpp"
 
-zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    routing_socket_base_t (parent_, tid_, sid_),
+zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    routing_socket_base_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _prefetched (false),
     _routing_id_sent (false),
     _current_in (NULL),

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -48,7 +48,7 @@ class pipe_t;
 class router_t : public routing_socket_base_t
 {
   public:
-    router_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    router_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~router_t () ZMQ_OVERRIDE;
 
     //  Overrides of functions from socket_base_t.

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -72,6 +72,8 @@ class socket_base_t : public own_t,
     //  Create a socket of a specified type.
     static socket_base_t *
     create (int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    static socket_base_t *
+    create_router (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
 
     //  Returns the mailbox associated with this socket.
     i_mailbox *get_mailbox () const;
@@ -355,7 +357,7 @@ class socket_base_t : public own_t,
 class routing_socket_base_t : public socket_base_t
 {
   protected:
-    routing_socket_base_t (class ctx_t *parent_, uint32_t tid_, int sid_);
+    routing_socket_base_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~routing_socket_base_t () ZMQ_OVERRIDE;
 
     // methods from socket_base_t
@@ -396,6 +398,10 @@ class routing_socket_base_t : public socket_base_t
     //  Outbound pipes indexed by the peer IDs.
     typedef std::map<blob_t, out_pipe_t> out_pipes_t;
     out_pipes_t _out_pipes;
+
+    // peer connection-notification function
+    zmq_router_skt_peer_connect_notification_fn *_cnfn;
+    void *_cnfnhint;
 
     // Next assigned name on a zmq_connect() call used by ROUTER and STREAM socket types
     std::string _connect_routing_id;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -36,8 +36,8 @@
 #include "likely.hpp"
 #include "err.hpp"
 
-zmq::stream_t::stream_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    routing_socket_base_t (parent_, tid_, sid_),
+zmq::stream_t::stream_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    routing_socket_base_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _prefetched (false),
     _routing_id_sent (false),
     _current_out (NULL),

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -42,7 +42,7 @@ class pipe_t;
 class stream_t ZMQ_FINAL : public routing_socket_base_t
 {
   public:
-    stream_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    stream_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~stream_t ();
 
     //  Overrides of functions from socket_base_t.

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -260,6 +260,17 @@ void *zmq_socket (void *ctx_, int type_)
     return static_cast<void *> (s);
 }
 
+void *zmq_new_router_socket (void * ctx_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_)
+{
+    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+        errno = EFAULT;
+        return NULL;
+    }
+    zmq::ctx_t *ctx = static_cast<zmq::ctx_t *> (ctx_);
+    zmq::socket_base_t *s = ctx->create_router_socket (cnfn_, cnfnhint_);
+    return static_cast<void *> (s);
+}
+
 int zmq_close (void *s_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);


### PR DESCRIPTION
…e peer [dis]connection callback" that is invoked whenever a remote peer connects or disconnects and passes along its "remote ID", the same one that will be found in the first message frame of all messages incoming from that peer. This should allow vantBroker to robustly maintain its data structures.