### PR TITLE
externpro 26.01.1-56-g8c1588f

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 4.3.5.1 tag",
+  "tag": "xpv4.3.5.1"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,8 @@ zeromq-*.zip
 core
 
 mybuild
+
+# externpro
+.env
+_bld*/
+docker-compose.override.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 # CMake build script for ZeroMQ
+cmake_minimum_required(VERSION 3.0.2...4.3)
 project(ZeroMQ)
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
-  cmake_minimum_required(VERSION 3.0.2)
-else()
-  cmake_minimum_required(VERSION 2.8.12)
-endif()
 
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)
@@ -265,6 +260,18 @@ option(ENABLE_CURVE "Enable CURVE security" OFF)
 
 if(ENABLE_CURVE)
   if(WITH_LIBSODIUM)
+    if(COMMAND xpFindPkg)
+      xpFindPkg(PKGS libsodium)
+      message(STATUS "Using libsodium for CURVE security")
+      get_target_property(SODIUM_INCLUDE_DIRS libsodium::sodium INTERFACE_INCLUDE_DIRECTORIES)
+      get_target_property(SODIUM_DEFS libsodium::sodium INTERFACE_COMPILE_DEFINITIONS)
+      include_directories(${SODIUM_INCLUDE_DIRS})
+      add_compile_definitions(${SODIUM_DEFS})
+      set(ZMQ_USE_LIBSODIUM 1)
+      set(ZMQ_HAVE_CURVE 1)
+      set(SODIUM_FOUND TRUE)
+      set(SODIUM_LIBRARIES libsodium::sodium)
+    else()
     find_package("sodium")
     if(SODIUM_FOUND)
       message(STATUS "Using libsodium for CURVE security")
@@ -283,6 +290,7 @@ if(ENABLE_CURVE)
         ERROR
           "libsodium not installed, you may want to install libsodium and run cmake again"
       )
+    endif()
     endif()
   endif()
 else()
@@ -1235,7 +1243,7 @@ set(VERSION ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc @ONLY)
 set(zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
 
-if(NOT ZMQ_BUILD_FRAMEWORK)
+if(NOT ZMQ_BUILD_FRAMEWORK AND NOT COMMAND xpExternPackage)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
@@ -1459,7 +1467,8 @@ endif()
 foreach(target ${build_targets})
   target_include_directories(
     ${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
+                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   if(ENABLE_DRAFTS)
     target_compile_definitions(${target} PUBLIC ZMQ_BUILD_DRAFT_API)
@@ -1623,7 +1632,7 @@ if(BUILD_SHARED)
           VERBATIM
           COMMENT "Perf tools")
       else()
-        install(TARGETS ${perf-tool} RUNTIME DESTINATION bin COMPONENT PerfTools)
+        install(TARGETS ${perf-tool} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT PerfTools)
       endif()
       if(ZMQ_HAVE_WINDOWS_UWP)
         set_target_properties(${perf-tool} PROPERTIES LINK_FLAGS_DEBUG "/OPT:NOICF /OPT:NOREF")
@@ -1669,6 +1678,22 @@ endif()
 # -----------------------------------------------------------------------------
 # installer
 
+set(targetsFile ${PROJECT_NAME}Targets)
+if(COMMAND xpExternPackage)
+  xpExternPackage(REPO_NAME libzmq
+    TARGETS_FILE ${targetsFile} EXPORT ${PROJECT_NAME}-targets
+    CREATE_ALIASES PKG_CMAKE_USEXT
+    LIBRARIES libzmq-static DEFAULT_TARGETS libzmq-static
+    BASE v${VERSION} XPDIFF "patch"
+    WEB "https://zeromq.org/" UPSTREAM "github.com/zeromq/libzmq"
+    DESC "high-performance asynchronous messaging library"
+    LICENSE "[MPL-2.0](http://wiki.zeromq.org/area:licensing 'Mozilla Public License 2.0')"
+    )
+  set(nSpace libzmq::)
+  set(nameSpace NAMESPACE ${nSpace})
+  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR ${CMAKE_INSTALL_CMAKEDIR} CACHE STRING "install path for ZeroMQConfig.cmake")
+endif()
+
 if(MSVC AND (BUILD_SHARED OR BUILD_STATIC))
   install(
     TARGETS ${target_outputs}
@@ -1711,7 +1736,7 @@ foreach(readme ${readme-docs})
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
 
   if(NOT ZMQ_BUILD_FRAMEWORK)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
 endforeach()
 
@@ -1719,7 +1744,7 @@ if(WITH_DOC)
   if(NOT ZMQ_BUILD_FRAMEWORK)
     install(
       FILES ${html-docs}
-      DESTINATION doc/zmq
+      DESTINATION ${CMAKE_INSTALL_DOCDIR}
       COMPONENT RefGuide)
   endif()
 endif()
@@ -1737,7 +1762,7 @@ else()
 endif()
 
 if((NOT CMAKE_VERSION VERSION_LESS 3.0) AND (BUILD_SHARED OR BUILD_STATIC))
-  export(EXPORT ${PROJECT_NAME}-targets FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+  export(EXPORT ${PROJECT_NAME}-targets FILE "${CMAKE_CURRENT_BINARY_DIR}/${targetsFile}.cmake")
 endif()
 configure_package_config_file(
   builds/cmake/${PROJECT_NAME}Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
@@ -1749,7 +1774,7 @@ write_basic_package_version_file(
 if(BUILD_SHARED OR BUILD_STATIC)
   install(
     EXPORT ${PROJECT_NAME}-targets
-    FILE ${PROJECT_NAME}Targets.cmake
+    FILE ${targetsFile}.cmake ${nameSpace}
     DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
                 ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake

--- a/builds/cmake/ZeroMQConfig.cmake.in
+++ b/builds/cmake/ZeroMQConfig.cmake.in
@@ -4,8 +4,8 @@
 #
 # ::
 #
-#   libzmq-static
-#   libzmq
+#   @nSpace@libzmq-static
+#   @nSpace@libzmq
 #
 # This module sets the following variables in your project::
 #
@@ -16,19 +16,19 @@
 
 @PACKAGE_INIT@
 
-if(NOT TARGET libzmq AND NOT TARGET libzmq-static)
+if(NOT TARGET @nSpace@libzmq AND NOT TARGET @nSpace@libzmq-static)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
-  if (TARGET libzmq)
-    get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq INTERFACE_INCLUDE_DIRECTORIES)
+  if (TARGET @nSpace@libzmq)
+    get_target_property(@PROJECT_NAME@_INCLUDE_DIR @nSpace@libzmq INTERFACE_INCLUDE_DIRECTORIES)
   else ()
-    get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq-static INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(@PROJECT_NAME@_INCLUDE_DIR @nSpace@libzmq-static INTERFACE_INCLUDE_DIRECTORIES)
   endif()
 
-  if (TARGET libzmq)
-    get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
+  if (TARGET @nSpace@libzmq)
+    get_target_property(@PROJECT_NAME@_LIBRARY @nSpace@libzmq LOCATION)
   endif()
-  if (TARGET libzmq-static)
-    get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
+  if (TARGET @nSpace@libzmq-static)
+    get_target_property(@PROJECT_NAME@_STATIC_LIBRARY @nSpace@libzmq-static LOCATION)
   endif()
 endif()

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -445,6 +445,9 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_PROTOCOL_ERROR_WS_UNSPECIFIED 0x30000000
 
 ZMQ_EXPORT void *zmq_socket (void *, int type_);
+typedef void(zmq_router_skt_peer_connect_notification_fn) (const unsigned char* rmtID_, size_t rmtIDLen_, int connectingElseDisconnecting_, void *hint_);
+ZMQ_EXPORT void *zmq_new_router_socket (void * context_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
+
 ZMQ_EXPORT int zmq_close (void *s_);
 ZMQ_EXPORT int
 zmq_setsockopt (void *s_, int option_, const void *optval_, size_t optvallen_);

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -780,6 +780,11 @@ ZMQ_EXPORT int zmq_ppoll (zmq_pollitem_t *items_,
 
 #endif // ZMQ_BUILD_DRAFT_API
 
+// expose socket option ZMQ_METADATA, which is currently only available in the
+// draft API:
+#ifndef ZMQ_METADATA
+#define ZMQ_METADATA 95
+#endif
 
 #undef ZMQ_EXPORT
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -455,8 +455,12 @@ fail_cleanup_slots:
     return false;
 }
 
-zmq::socket_base_t *zmq::ctx_t::create_socket (int type_)
+zmq::socket_base_t *zmq::ctx_t::create_socket (int type_, std::function<zmq::socket_base_t*(int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_)> sktAllocFn)
 {
+  if(!sktAllocFn)
+  {
+    sktAllocFn = [](int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_){return socket_base_t::create (type_, parent_, tid_, sid_);};
+  }
     scoped_lock_t locker (_slot_sync);
 
     //  Once zmq_ctx_term() or zmq_ctx_shutdown() was called, we can't create
@@ -485,7 +489,7 @@ zmq::socket_base_t *zmq::ctx_t::create_socket (int type_)
     const int sid = (static_cast<int> (max_socket_id.add (1))) + 1;
 
     //  Create the socket and register its mailbox.
-    socket_base_t *s = socket_base_t::create (type_, this, slot, sid);
+    socket_base_t *s = sktAllocFn(type_, this, slot, sid);
     if (!s) {
         _empty_slots.push_back (slot);
         return NULL;
@@ -494,6 +498,14 @@ zmq::socket_base_t *zmq::ctx_t::create_socket (int type_)
     _slots[slot] = s->get_mailbox ();
 
     return s;
+}
+
+zmq::socket_base_t *zmq::ctx_t::create_router_socket (zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_)
+{
+  return create_socket(0, [cnfn_, cnfnhint_](int, zmq::ctx_t *parent_, uint32_t tid_, int sid_)
+  {
+    return socket_base_t::create_router( parent_, tid_, sid_, cnfn_, cnfnhint_);
+  });
 }
 
 void zmq::ctx_t::destroy_socket (class socket_base_t *socket_)

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -3,6 +3,7 @@
 #ifndef __ZMQ_CTX_HPP_INCLUDED__
 #define __ZMQ_CTX_HPP_INCLUDED__
 
+#include <functional>
 #include <map>
 #include <vector>
 #include <string>
@@ -93,7 +94,9 @@ class ctx_t ZMQ_FINAL : public thread_ctx_t
     int get (int option_);
 
     //  Create and destroy a socket.
-    zmq::socket_base_t *create_socket (int type_);
+    // if sktAllocFn is empty then it will allocate it using socket_base_t::create(...)
+    zmq::socket_base_t *create_socket (int type_, std::function<zmq::socket_base_t*(int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_)> sktAllocFn = {});
+    zmq::socket_base_t *create_router_socket (zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     void destroy_socket (zmq::socket_base_t *socket_);
 
     //  Send command to the destination thread.

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -383,13 +383,19 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
                               _cn_secret);
     zmq_assert (rc == 0);
 
+    // parse the metadata BEFORE doing ZAP authentication so that ZAP can use
+    // any applicable metadata:
+    auto retMetadata = parse_metadata (
+      &initiate_plaintext[crypto_box_ZEROBYTES + 128],
+      clen - crypto_box_ZEROBYTES - 128);
+
     //  Given this is a backward-incompatible change, it's behind a socket
     //  option disabled by default.
     if (zap_required () || !options.zap_enforce_domain) {
         //  Use ZAP protocol (RFC 27) to authenticate the user.
         rc = session->zap_connect ();
         if (rc == 0) {
-            send_zap_request (client_key);
+            send_zap_request (client_key, _signature);
             state = waiting_for_zap_reply;
 
             //  TODO actually, it is quite unlikely that we can read the ZAP
@@ -412,8 +418,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
         state = sending_ready;
     }
 
-    return parse_metadata (&initiate_plaintext[crypto_box_ZEROBYTES + 128],
-                           clen - crypto_box_ZEROBYTES - 128);
+    return retMetadata;
 }
 
 int zmq::curve_server_t::produce_ready (msg_t *msg_)
@@ -470,10 +475,32 @@ int zmq::curve_server_t::produce_error (msg_t *msg_) const
     return 0;
 }
 
-void zmq::curve_server_t::send_zap_request (const uint8_t *key_)
+void zmq::curve_server_t::send_zap_request (const uint8_t *key_,
+                                            const std::string& signature_)
 {
-    zap_client_t::send_zap_request ("CURVE", 5, key_,
-                                    crypto_box_PUBLICKEYBYTES);
+    // send not only the key but also an optional signature for the key, if one
+    // was present in the metadata:
+    if (signature_.empty())
+    {
+        zap_client_t::send_zap_request ("CURVE", 5, key_,
+                                        crypto_box_PUBLICKEYBYTES);
+    }
+    else
+    {
+        uint8_t* credentials[2] = { key_, signature_.data() };
+        size_t credentialSizes[2] = { crypto_box_PUBLICKEYBYTES,
+                                      signature_.size() };
+        zap_client_t::send_zap_request ("CURVE", 5, credentials,
+                                        credentialSizes, 2);
+    }
+}
+
+int zmq::curve_server_t::property (const std::string &name_, const void *value_,
+                                   size_t length_)
+{
+    if (name_ == "X-ClientKeySignature" && value_ && length_)
+        _signature.assign(value_, length_);
+    return 0; // success
 }
 
 #endif

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -487,7 +487,9 @@ void zmq::curve_server_t::send_zap_request (const uint8_t *key_,
     }
     else
     {
-        uint8_t* credentials[2] = { key_, signature_.data() };
+        const uint8_t* credentials[2] = { key_,
+          static_cast<const uint8_t*>(
+            static_cast<const void*>(signature_.data())) };
         size_t credentialSizes[2] = { crypto_box_PUBLICKEYBYTES,
                                       signature_.size() };
         zap_client_t::send_zap_request ("CURVE", 5, credentials,
@@ -499,7 +501,7 @@ int zmq::curve_server_t::property (const std::string &name_, const void *value_,
                                    size_t length_)
 {
     if (name_ == "X-ClientKeySignature" && value_ && length_)
-        _signature.assign(value_, length_);
+        _signature.assign(static_cast<const char*>(value_), length_);
     return 0; // success
 }
 

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -47,7 +47,7 @@ class curve_server_t ZMQ_FINAL : public zap_client_common_handshake_t,
     //  Key used to produce cookie
     uint8_t _cookie_key[crypto_secretbox_KEYBYTES];
 
-    //  Signature for client's public key, if provided
+    //  Signature for client's public key, empty() if not provided
     std::string _signature;
 
     int process_hello (msg_t *msg_);

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -47,13 +47,21 @@ class curve_server_t ZMQ_FINAL : public zap_client_common_handshake_t,
     //  Key used to produce cookie
     uint8_t _cookie_key[crypto_secretbox_KEYBYTES];
 
+    //  Signature for client's public key, if provided
+    std::string _signature;
+
     int process_hello (msg_t *msg_);
     int produce_welcome (msg_t *msg_);
     int process_initiate (msg_t *msg_);
     int produce_ready (msg_t *msg_);
     int produce_error (msg_t *msg_) const;
 
-    void send_zap_request (const uint8_t *key_);
+    void send_zap_request (const uint8_t *key_,
+                           const std::string& signature_);
+
+    int property (const std::string &name_, const void *value_, size_t length_)
+      override;
+
 };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/rep.cpp
+++ b/src/rep.cpp
@@ -5,8 +5,8 @@
 #include "err.hpp"
 #include "msg.hpp"
 
-zmq::rep_t::rep_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    router_t (parent_, tid_, sid_),
+zmq::rep_t::rep_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    router_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _sending_reply (false),
     _request_begins (true)
 {

--- a/src/rep.hpp
+++ b/src/rep.hpp
@@ -15,7 +15,7 @@ class socket_base_t;
 class rep_t ZMQ_FINAL : public router_t
 {
   public:
-    rep_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    rep_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~rep_t ();
 
     //  Overrides of functions from socket_base_t.

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -9,8 +9,8 @@
 #include "likely.hpp"
 #include "err.hpp"
 
-zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    routing_socket_base_t (parent_, tid_, sid_),
+zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    routing_socket_base_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _prefetched (false),
     _routing_id_sent (false),
     _current_in (NULL),

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -21,7 +21,7 @@ class pipe_t;
 class router_t : public routing_socket_base_t
 {
   public:
-    router_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    router_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~router_t () ZMQ_OVERRIDE;
 
     //  Overrides of functions from socket_base_t.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -144,13 +144,13 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_,
             s = new (std::nothrow) req_t (parent_, tid_, sid_);
             break;
         case ZMQ_REP:
-            s = new (std::nothrow) rep_t (parent_, tid_, sid_);
+            s = new (std::nothrow) rep_t (parent_, tid_, sid_, nullptr, nullptr);
             break;
         case ZMQ_DEALER:
             s = new (std::nothrow) dealer_t (parent_, tid_, sid_);
             break;
         case ZMQ_ROUTER:
-            s = new (std::nothrow) router_t (parent_, tid_, sid_);
+            s = new (std::nothrow) router_t (parent_, tid_, sid_, nullptr, nullptr);
             break;
         case ZMQ_PULL:
             s = new (std::nothrow) pull_t (parent_, tid_, sid_);
@@ -165,7 +165,7 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_,
             s = new (std::nothrow) xsub_t (parent_, tid_, sid_);
             break;
         case ZMQ_STREAM:
-            s = new (std::nothrow) stream_t (parent_, tid_, sid_);
+            s = new (std::nothrow) stream_t (parent_, tid_, sid_, nullptr, nullptr);
             break;
         case ZMQ_SERVER:
             s = new (std::nothrow) server_t (parent_, tid_, sid_);
@@ -199,6 +199,21 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_,
             return NULL;
     }
 
+    alloc_assert (s);
+
+    if (s->_mailbox == NULL) {
+        s->_destroyed = true;
+        LIBZMQ_DELETE (s);
+        return NULL;
+    }
+
+    return s;
+}
+
+zmq::socket_base_t *
+zmq::socket_base_t::create_router (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_)
+{
+    socket_base_t *s = new (std::nothrow) router_t (parent_, tid_, sid_, cnfn_, cnfnhint_);
     alloc_assert (s);
 
     if (s->_mailbox == NULL) {
@@ -2048,8 +2063,10 @@ bool zmq::socket_base_t::is_disconnected () const
 
 zmq::routing_socket_base_t::routing_socket_base_t (class ctx_t *parent_,
                                                    uint32_t tid_,
-                                                   int sid_) :
+                                                   int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
     socket_base_t (parent_, tid_, sid_)
+   ,_cnfn(cnfn_)
+   ,_cnfnhint(cnfnhint_)
 {
 }
 
@@ -2111,6 +2128,10 @@ void zmq::routing_socket_base_t::add_out_pipe (blob_t routing_id_,
       _out_pipes.ZMQ_MAP_INSERT_OR_EMPLACE (ZMQ_MOVE (routing_id_), outpipe)
         .second;
     zmq_assert (ok);
+    if(_cnfn)
+    {
+      _cnfn(routing_id_.data(), routing_id_.size(), 1/*true: is connecting*/, _cnfnhint);
+    }
 }
 
 bool zmq::routing_socket_base_t::has_out_pipe (const blob_t &routing_id_) const
@@ -2136,8 +2157,13 @@ zmq::routing_socket_base_t::lookup_out_pipe (const blob_t &routing_id_) const
 
 void zmq::routing_socket_base_t::erase_out_pipe (const pipe_t *pipe_)
 {
-    const size_t erased = _out_pipes.erase (pipe_->get_routing_id ());
+  auto const& rmtId = pipe_->get_routing_id();
+    const size_t erased = _out_pipes.erase (rmtId);
     zmq_assert (erased);
+    if(_cnfn)
+    {
+      _cnfn(rmtId.data(), rmtId.size(), 0/*false: is disconnecting*/, _cnfnhint);
+    }
 }
 
 zmq::routing_socket_base_t::out_pipe_t
@@ -2148,6 +2174,10 @@ zmq::routing_socket_base_t::try_erase_out_pipe (const blob_t &routing_id_)
     if (it != _out_pipes.end ()) {
         res = it->second;
         _out_pipes.erase (it);
+        if(_cnfn)
+        {
+          _cnfn(routing_id_.data(), routing_id_.size(), 0/*false: is disconnecting*/, _cnfnhint);
+        }
     }
     return res;
 }

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -45,6 +45,8 @@ class socket_base_t : public own_t,
     //  Create a socket of a specified type.
     static socket_base_t *
     create (int type_, zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    static socket_base_t *
+    create_router (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
 
     //  Returns the mailbox associated with this socket.
     i_mailbox *get_mailbox () const;
@@ -333,7 +335,7 @@ class socket_base_t : public own_t,
 class routing_socket_base_t : public socket_base_t
 {
   protected:
-    routing_socket_base_t (class ctx_t *parent_, uint32_t tid_, int sid_);
+    routing_socket_base_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~routing_socket_base_t () ZMQ_OVERRIDE;
 
     // methods from socket_base_t
@@ -374,6 +376,10 @@ class routing_socket_base_t : public socket_base_t
     //  Outbound pipes indexed by the peer IDs.
     typedef std::map<blob_t, out_pipe_t> out_pipes_t;
     out_pipes_t _out_pipes;
+
+    // peer connection-notification function
+    zmq_router_skt_peer_connect_notification_fn *_cnfn;
+    void *_cnfnhint;
 
     // Next assigned name on a zmq_connect() call used by ROUTER and STREAM socket types
     std::string _connect_routing_id;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -9,8 +9,8 @@
 #include "likely.hpp"
 #include "err.hpp"
 
-zmq::stream_t::stream_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
-    routing_socket_base_t (parent_, tid_, sid_),
+zmq::stream_t::stream_t (class ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_) :
+    routing_socket_base_t (parent_, tid_, sid_, cnfn_, cnfnhint_),
     _prefetched (false),
     _routing_id_sent (false),
     _current_out (NULL),

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -15,7 +15,7 @@ class pipe_t;
 class stream_t ZMQ_FINAL : public routing_socket_base_t
 {
   public:
-    stream_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_);
+    stream_t (zmq::ctx_t *parent_, uint32_t tid_, int sid_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_);
     ~stream_t ();
 
     //  Overrides of functions from socket_base_t.

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -238,6 +238,17 @@ void *zmq_socket (void *ctx_, int type_)
     return static_cast<void *> (s);
 }
 
+void *zmq_new_router_socket (void * ctx_, zmq_router_skt_peer_connect_notification_fn *cnfn_, void *cnfnhint_)
+{
+    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+        errno = EFAULT;
+        return NULL;
+    }
+    zmq::ctx_t *ctx = static_cast<zmq::ctx_t *> (ctx_);
+    zmq::socket_base_t *s = ctx->create_router_socket (cnfn_, cnfnhint_);
+    return static_cast<void *> (s);
+}
+
 int zmq_close (void *s_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -306,7 +306,7 @@ foreach(test ${tests})
     endif()
   endif()
 
-  set_tests_properties(${test} PROPERTIES TIMEOUT 10)
+  set_tests_properties(${test} PROPERTIES TIMEOUT 15)
   set_tests_properties(${test} PROPERTIES SKIP_RETURN_CODE 77)
 
   if(QNX)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 2.8.1...4.3)
 
 # On Windows: solution file will be called tests.sln
 project(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -315,7 +315,7 @@ foreach(test ${tests})
 endforeach()
 
 # override timeout for these tests
-set_tests_properties(test_heartbeats PROPERTIES TIMEOUT 60)
+set_tests_properties(test_heartbeats PROPERTIES TIMEOUT 90)
 
 if(WIN32 AND ENABLE_DRAFTS)
   set_tests_properties(test_radio_dish PROPERTIES TIMEOUT 30)

--- a/tests/test_stream_disconnect.cpp
+++ b/tests/test_stream_disconnect.cpp
@@ -50,12 +50,11 @@ void test_stream_disconnect ()
       zmq_getsockopt (sockets[SERVER], ZMQ_LAST_ENDPOINT, bind_endpoint, &len));
 
     //  Apparently Windows can't connect to 0.0.0.0. A better fix would be welcome.
-#ifdef ZMQ_HAVE_WINDOWS
-    snprintf (connect_endpoint, MAX_SOCKET_STRING * sizeof (char),
-              "tcp://127.0.0.1:%s", strrchr (bind_endpoint, ':') + 1);
-#else
-    strcpy (connect_endpoint, bind_endpoint);
-#endif
+    if (strstr (bind_endpoint, "tcp://0.0.0.0:") == bind_endpoint)
+        snprintf (connect_endpoint, MAX_SOCKET_STRING * sizeof (char),
+                  "tcp://127.0.0.1:%s", strrchr (bind_endpoint, ':') + 1);
+    else
+        strcpy (connect_endpoint, bind_endpoint);
 
     sockets[CLIENT] = test_context_socket (ZMQ_STREAM);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (

--- a/tests/test_stream_exceeds_buffer.cpp
+++ b/tests/test_stream_exceeds_buffer.cpp
@@ -19,10 +19,16 @@ void test_stream_exceeds_buffer ()
     void *zsock = test_context_socket (ZMQ_STREAM);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (zsock, my_endpoint));
 
+    const int rcvtimeo = 5000;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (zsock, ZMQ_RCVTIMEO, &rcvtimeo, sizeof (rcvtimeo)));
+
     int client_sock =
       TEST_ASSERT_SUCCESS_RAW_ERRNO (accept (server_sock, NULL, NULL));
 
     TEST_ASSERT_SUCCESS_RAW_ERRNO (close (server_sock));
+
+    msleep (SETTLE_TIME);
 
     TEST_ASSERT_EQUAL_INT (msgsize, send (client_sock, sndbuf, msgsize, 0));
 

--- a/tests/test_unbind_wildcard.cpp
+++ b/tests/test_unbind_wildcard.cpp
@@ -22,12 +22,11 @@ void test_address_wildcard_ipv4 ()
       zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, bind_endpoint, &endpoint_len));
 
     //  Apparently Windows can't connect to 0.0.0.0. A better fix would be welcome.
-#ifdef ZMQ_HAVE_WINDOWS
-    snprintf (connect_endpoint, 256 * sizeof (char), "tcp://127.0.0.1:%s",
-              strrchr (bind_endpoint, ':') + 1);
-#else
-    strcpy (connect_endpoint, bind_endpoint);
-#endif
+    if (strstr (bind_endpoint, "tcp://0.0.0.0:") == bind_endpoint)
+        snprintf (connect_endpoint, 256 * sizeof (char), "tcp://127.0.0.1:%s",
+                  strrchr (bind_endpoint, ':') + 1);
+    else
+        strcpy (connect_endpoint, bind_endpoint);
 
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, connect_endpoint));
 
@@ -70,7 +69,14 @@ void test_address_wildcard_ipv6 ()
         snprintf (connect_endpoint, 256 * sizeof (char), "tcp://127.0.0.1:%s",
                   strrchr (bind_endpoint, ':') + 1);
 #else
-    strcpy (connect_endpoint, bind_endpoint);
+    if (ipv6 && strstr (bind_endpoint, "tcp://[::]:") == bind_endpoint)
+        snprintf (connect_endpoint, MAX_SOCKET_STRING * sizeof (char),
+                  "tcp://[::1]:%s", strrchr (bind_endpoint, ':') + 1);
+    else if (!ipv6 && strstr (bind_endpoint, "tcp://0.0.0.0:") == bind_endpoint)
+        snprintf (connect_endpoint, MAX_SOCKET_STRING * sizeof (char),
+                  "tcp://127.0.0.1:%s", strrchr (bind_endpoint, ':') + 1);
+    else
+        strcpy (connect_endpoint, bind_endpoint);
 #endif
 
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, connect_endpoint));

--- a/tests/test_zmq_poll_fd.cpp
+++ b/tests/test_zmq_poll_fd.cpp
@@ -22,6 +22,7 @@ void test_poll_fd ()
       setsockopt (recv_socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof (int)));
 
     struct sockaddr_in saddr = bind_bsd_socket (recv_socket);
+    saddr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
 
     void *sb = test_context_socket (ZMQ_REP);
 

--- a/tests/test_zmq_ppoll_fd.cpp
+++ b/tests/test_zmq_ppoll_fd.cpp
@@ -23,6 +23,7 @@ void test_ppoll_fd ()
       setsockopt (recv_socket, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof (int)));
 
     struct sockaddr_in saddr = bind_bsd_socket (recv_socket);
+    saddr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
 
     void *sb = test_context_socket (ZMQ_REP);
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ unit tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 2.8.1...4.3)
 
 set(unittests
     unittest_ypipe


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-56-g8c1588f`
Update to branch off upstream `v4.3.5` tag

## Changes

- Updated `.devcontainer` to externpro `26.01.1-56-g8c1588f`
- Previous HEAD: `a2e89c849bc0cee02e7a5813c98f2c147509f7cc`
- New HEAD: `8c1588fb6fcb3691cbf6d27ff7a3bb2b0b0290ad`
- If you add the \"release:tag\" label, the tag will be \`xpv4.3.5.1\`

---

*This PR was created automatically by GitHub Actions*
