### PR TITLE
externpro 26.01.1-57-g9bf20bf

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 4.3.5.1 tag",
-  "tag": "xpv4.3.5.1"
+  "message": "xpro version 4.3.5.2 tag",
+  "tag": "xpv4.3.5.2"
 }

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,6 +6,8 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
+        "ENABLE_CURVE": "ON",
+        "WITH_LIBSODIUM": "ON",
         "WITH_TLS": "OFF",
         "BUILD_SHARED": "OFF",
         "ENABLE_CPACK": "OFF",

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -26,10 +26,10 @@ class curve_server_t ZMQ_FINAL : public zap_client_common_handshake_t,
     ~curve_server_t ();
 
     // mechanism implementation
-    int next_handshake_command (msg_t *msg_);
-    int process_handshake_command (msg_t *msg_);
-    int encode (msg_t *msg_);
-    int decode (msg_t *msg_);
+    int next_handshake_command (msg_t *msg_) override;
+    int process_handshake_command (msg_t *msg_) override;
+    int encode (msg_t *msg_) override;
+    int decode (msg_t *msg_) override;
 
   private:
     //  Our secret key (s)

--- a/tests/test_bind_curve_fuzzer.cpp
+++ b/tests/test_bind_curve_fuzzer.cpp
@@ -111,7 +111,7 @@ void test_bind_curve_fuzzer ()
     free (len);
 }
 
-int main (int argc, char **argv)
+int main (int /*argc*/, char ** /*argv*/)
 {
     setup_test_environment ();
 

--- a/tests/test_connect_curve_fuzzer.cpp
+++ b/tests/test_connect_curve_fuzzer.cpp
@@ -100,7 +100,7 @@ void test_connect_curve_fuzzer ()
     free (len);
 }
 
-int main (int argc, char **argv)
+int main (int /*argc*/, char ** /*argv*/)
 {
     setup_test_environment ();
 

--- a/tests/test_z85_decode_fuzzer.cpp
+++ b/tests/test_z85_decode_fuzzer.cpp
@@ -51,7 +51,7 @@ void test_z85_decode_fuzzer ()
     free (len);
 }
 
-int main (int argc, char **argv)
+int main (int /*argc*/, char ** /*argv*/)
 {
     setup_test_environment ();
 


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-57-g9bf20bf`
`ENABLE_CURVE` and `WITH_LIBSODIUM`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-57-g9bf20bf`
- Previous HEAD: `8c1588fb6fcb3691cbf6d27ff7a3bb2b0b0290ad`
- New HEAD: `9bf20bf44e3990872dd9767f7b61c4eab35e7c73`
- Updated `.github/release-tag.json` (tag: `xpv4.3.5.2`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv4.3.5.2\`

---

*This PR was created automatically by GitHub Actions*
